### PR TITLE
Integrate v2.11.0

### DIFF
--- a/.compose/.env
+++ b/.compose/.env
@@ -1,0 +1,3 @@
+YB_IMAGE=yugabytedb/yugabyte:2.11.0.0-b7
+YB_USER=yugabyte
+YB_MOUNT_PREFIX=/mnt/disk0

--- a/.compose/yugabytedb-minimal.yml
+++ b/.compose/yugabytedb-minimal.yml
@@ -1,0 +1,50 @@
+version: '3.9'
+
+networks:
+  yb-client-minimal:
+    name: yb-client-minimal
+
+services:
+
+  yb-master:
+    image: ${YB_IMAGE}
+    container_name: yb-master
+    networks:
+      - yb-client-minimal
+    ports:
+      - 7000:7000
+      - 7100:7100
+    command: [ "/home/${YB_USER}/bin/yb-master",
+      "--callhome_enabled=false",
+      "--fs_data_dirs=${YB_MOUNT_PREFIX}/master",
+      "--master_addresses=yb-master:7100",
+      "--rpc_bind_addresses=yb-master:7100",
+      "--logtostderr",
+      "--minloglevel=1",
+      "--placement_cloud=docker",
+      "--stop_on_parent_termination",
+      "--undefok=stop_on_parent_termination",
+      "--replication_factor=1" ]
+
+  yb-tserver:
+    image: ${YB_IMAGE}
+    container_name: yb-tserver
+    networks:
+      - yb-client-minimal
+    ports:
+      - 5433:5433
+      - 9000:9000
+      - 9100:9100
+    command: [ "/home/${YB_USER}/bin/yb-tserver",
+      "--callhome_enabled=false",
+      "--fs_data_dirs=${YB_MOUNT_PREFIX}/tserver",
+      "--enable_ysql",
+      "--ysql_enable_auth",
+      "--logtostderr",
+      "--rpc_bind_addresses=yb-tserver:9100",
+      "--tserver_master_addrs=yb-master:7100",
+      "--placement_cloud=docker",
+      "--placement_region=yb",
+      "--placement_zone=client1",
+      "--stop_on_parent_termination",
+      "--undefok=stop_on_parent_termination" ]

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/hashicorp/go-hclog v0.16.2
-	github.com/radekg/yugabyte-db-go-proto/v2 v2.7.2
+	github.com/radekg/yugabyte-db-go-proto/v2 v2.11.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -210,8 +210,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/radekg/yugabyte-db-go-proto/v2 v2.7.2 h1:Ok4wRC8RhwdSUAXNZX5e/cGu8pddVLXAqssGZ5/A1DA=
-github.com/radekg/yugabyte-db-go-proto/v2 v2.7.2/go.mod h1:CT2eg+ZbU1T/0rg19EchSuZxWdAeS9ciiiP6aWc0/aI=
+github.com/radekg/yugabyte-db-go-proto/v2 v2.11.0 h1:AuDgi8qjzsXNy0YlwIIAU06zhoDRwxRFMI8oVD2aLk8=
+github.com/radekg/yugabyte-db-go-proto/v2 v2.11.0/go.mod h1:CT2eg+ZbU1T/0rg19EchSuZxWdAeS9ciiiP6aWc0/aI=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
This PR:

- updates the protobuf dependency to v2.11.0
- fixes reading RPC responses
- adds a minimal compose file for quick tests