### PR TITLE
Get tablets for table

### DIFF
--- a/.compose/yugabytedb-minimal.yml
+++ b/.compose/yugabytedb-minimal.yml
@@ -6,9 +6,9 @@ networks:
 
 services:
 
-  yb-master:
+  yb-master-1:
     image: ${YB_IMAGE}
-    container_name: yb-master
+    container_name: yb-master-1
     networks:
       - yb-client-minimal
     ports:
@@ -17,18 +17,52 @@ services:
     command: [ "/home/${YB_USER}/bin/yb-master",
       "--callhome_enabled=false",
       "--fs_data_dirs=${YB_MOUNT_PREFIX}/master",
-      "--master_addresses=yb-master:7100",
-      "--rpc_bind_addresses=yb-master:7100",
+      "--master_addresses=yb-master-1:7100,yb-master-2:7100,yb-master-3:7100",
+      "--rpc_bind_addresses=yb-master-1:7100",
       "--logtostderr",
       "--minloglevel=1",
       "--placement_cloud=docker",
       "--stop_on_parent_termination",
       "--undefok=stop_on_parent_termination",
-      "--replication_factor=1" ]
+      "--replication_factor=3" ]
 
-  yb-tserver:
+  yb-master-2:
     image: ${YB_IMAGE}
-    container_name: yb-tserver
+    container_name: yb-master-2
+    networks:
+      - yb-client-minimal
+    command: [ "/home/${YB_USER}/bin/yb-master",
+      "--callhome_enabled=false",
+      "--fs_data_dirs=${YB_MOUNT_PREFIX}/master",
+      "--master_addresses=yb-master-1:7100,yb-master-2:7100,yb-master-3:7100",
+      "--rpc_bind_addresses=yb-master-2:7100",
+      "--logtostderr",
+      "--minloglevel=1",
+      "--placement_cloud=docker",
+      "--stop_on_parent_termination",
+      "--undefok=stop_on_parent_termination",
+      "--replication_factor=3" ]
+
+  yb-master-3:
+    image: ${YB_IMAGE}
+    container_name: yb-master-3
+    networks:
+      - yb-client-minimal
+    command: [ "/home/${YB_USER}/bin/yb-master",
+      "--callhome_enabled=false",
+      "--fs_data_dirs=${YB_MOUNT_PREFIX}/master",
+      "--master_addresses=yb-master-1:7100,yb-master-2:7100,yb-master-3:7100",
+      "--rpc_bind_addresses=yb-master-3:7100",
+      "--logtostderr",
+      "--minloglevel=1",
+      "--placement_cloud=docker",
+      "--stop_on_parent_termination",
+      "--undefok=stop_on_parent_termination",
+      "--replication_factor=3" ]
+
+  yb-tserver-1:
+    image: ${YB_IMAGE}
+    container_name: yb-tserver-1
     networks:
       - yb-client-minimal
     ports:
@@ -41,8 +75,46 @@ services:
       "--enable_ysql",
       "--ysql_enable_auth",
       "--logtostderr",
-      "--rpc_bind_addresses=yb-tserver:9100",
-      "--tserver_master_addrs=yb-master:7100",
+      "--rpc_bind_addresses=yb-tserver-1:9100",
+      "--tserver_master_addrs=yb-master-1:7100,yb-master-2:7100,yb-master-3:7100",
+      "--placement_cloud=docker",
+      "--placement_region=yb",
+      "--placement_zone=client1",
+      "--stop_on_parent_termination",
+      "--undefok=stop_on_parent_termination" ]
+
+  yb-tserver-2:
+    image: ${YB_IMAGE}
+    container_name: yb-tserver-2
+    networks:
+      - yb-client-minimal
+    command: [ "/home/${YB_USER}/bin/yb-tserver",
+      "--callhome_enabled=false",
+      "--fs_data_dirs=${YB_MOUNT_PREFIX}/tserver",
+      "--enable_ysql",
+      "--ysql_enable_auth",
+      "--logtostderr",
+      "--rpc_bind_addresses=yb-tserver-2:9100",
+      "--tserver_master_addrs=yb-master-1:7100,yb-master-2:7100,yb-master-3:7100",
+      "--placement_cloud=docker",
+      "--placement_region=yb",
+      "--placement_zone=client1",
+      "--stop_on_parent_termination",
+      "--undefok=stop_on_parent_termination" ]
+
+  yb-tserver-3:
+    image: ${YB_IMAGE}
+    container_name: yb-tserver-3
+    networks:
+      - yb-client-minimal
+    command: [ "/home/${YB_USER}/bin/yb-tserver",
+      "--callhome_enabled=false",
+      "--fs_data_dirs=${YB_MOUNT_PREFIX}/tserver",
+      "--enable_ysql",
+      "--ysql_enable_auth",
+      "--logtostderr",
+      "--rpc_bind_addresses=yb-tserver-3:9100",
+      "--tserver_master_addrs=yb-master-1:7100,yb-master-2:7100,yb-master-3:7100",
       "--placement_cloud=docker",
       "--placement_region=yb",
       "--placement_zone=client1",

--- a/README.md
+++ b/README.md
@@ -164,19 +164,18 @@ Examples:
 
 - `--name-filter`: string, When used, only returns tables that satisfy a substring match on `name_filter`, default `empty string`
 - `--keyspace`: string, the namespace name to fetch info, default `empty string`
-- `--namespace-type`: string, database type - one of `cql`, `pgsql`, `redis`, default `cql`
 - `--exclude-system-tables`: boolean, exclude system tables, default `false`
 - `--include-not-running`: boolean, include not running, default `false`
 - `--relation-type`: list of strings, filter tables based on RelationType - supported values: `system_table`, `user_table`, `index`, default: all values
 
 Examples:
 
-- list all regardless of namespace type: `cli list-tables`
-- list all PostgreSQL `system_platform` relations: `cli list-tables --keyspace system_platform --namespace-type pgsql`
-- list all PostgreSQL `postgres` relations: `cli list-tables --keyspace postgres --namespace-type pgsql`
-- list all PostgreSQL `template0` relations: `cli list-tables --keyspace template0 --namespace-type pgsql`
-- list all CQL `system_schema` relations: `cli list-tables --keyspace system_schema --namespace-type cql`
-- list all Redis `system_redis` relations: `cli list-tables --keyspace system_redis --namespace-type redis`
+- list all PostgreSQL `system_platform` relations: `cli list-tables --keyspace ysql.system_platform`
+- list all PostgreSQL `postgres` relations: `cli list-tables --keyspace ysql.postgres`
+- list all PostgreSQL `yugabyte` relations: `cli list-tables --keyspace ysql.yugabyte`
+- list all PostgreSQL `template0` relations: `cli list-tables --keyspace ysql.template0`
+- list all CQL `system_schema` relations: `cli list-tables --keyspace ycql.system_schema`
+- list all Redis `system_redis` relations: `cli list-tables --keyspace yedis.system_redis`
 
 #### list-tablet-servers
 

--- a/client/base/client.go
+++ b/client/base/client.go
@@ -303,7 +303,7 @@ func (c *ybDefaultConnectedClient) readResponseInto(reader *bytes.Buffer, m prot
 
 	protoErr2 := proto.Unmarshal(responsePayloadBuf, m)
 	if protoErr2 != nil {
-		opLogger.Error("failed unmarshalling response payload", "reason", protoErr2)
+		opLogger.Error("failed unmarshalling response payload", "reason", protoErr2, "consumed-data", string(responsePayloadBuf))
 		return err
 	}
 

--- a/client/cli/cli_client.go
+++ b/client/cli/cli_client.go
@@ -15,6 +15,7 @@ type YBCliClient interface {
 	DescribeTable(*configs.OpGetTableSchemaConfig) (*ybApi.GetTableSchemaResponsePB, error)
 	GetLoadMoveCompletion() (*ybApi.GetLoadMovePercentResponsePB, error)
 	GetMasterRegistration() (*ybApi.GetMasterRegistrationResponsePB, error)
+	GetTabletsForTable(*configs.OpGetTableLocationsConfig) (*ybApi.GetTableLocationsResponsePB, error)
 	GetUniverseConfig() (*ybApi.GetMasterClusterConfigResponsePB, error)
 	IsLoadBalanced(*configs.OpIsLoadBalancedConfig) (*ybApi.IsLoadBalancedResponsePB, error)
 	IsTabletServerReady() (*ybApi.IsTabletServerReadyResponsePB, error)

--- a/client/cli/common.go
+++ b/client/cli/common.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/radekg/yugabyte-db-go-client/utils"
@@ -42,4 +43,80 @@ func (c *defaultYBCliClient) getTabletsForTableByUUID(tableID []byte, opConfig *
 		return nil, fmt.Errorf(err.String())
 	}
 	return responsePayload, nil
+}
+
+// ==
+// Keyspace handling
+
+type parsedKeyspace struct {
+	YQLDatabaseType string
+	Keyspace        string
+}
+
+func (pk *parsedKeyspace) toProtoKeyspace() *ybApi.NamespaceIdentifierPB {
+	if yqlDatabaseType, ok := mapYQLDatabaseType(pk.YQLDatabaseType); ok {
+		return &ybApi.NamespaceIdentifierPB{
+			Name:         &pk.Keyspace,
+			DatabaseType: pYQLDatabase(yqlDatabaseType),
+		}
+	}
+	return &ybApi.NamespaceIdentifierPB{
+		Name:         &pk.Keyspace,
+		DatabaseType: pYQLDatabase(ybApi.YQLDatabase_YQL_DATABASE_CQL),
+	}
+}
+
+func parseKeyspace(input string) *parsedKeyspace {
+	if strings.HasPrefix(input, "ycql.") {
+		return &parsedKeyspace{
+			YQLDatabaseType: "ycql",
+			Keyspace:        strings.TrimPrefix(input, "ycql."),
+		}
+	}
+	if strings.HasPrefix(input, "ysql.") {
+		return &parsedKeyspace{
+			YQLDatabaseType: "ysql",
+			Keyspace:        strings.TrimPrefix(input, "ysql."),
+		}
+	}
+	if strings.HasPrefix(input, "yedis.") {
+		return &parsedKeyspace{
+			YQLDatabaseType: "yedis",
+			Keyspace:        strings.TrimPrefix(input, "yedis."),
+		}
+	}
+	return &parsedKeyspace{
+		YQLDatabaseType: "ycql",
+		Keyspace:        input,
+	}
+}
+
+func mapYQLDatabaseType(input string) (ybApi.YQLDatabase, bool) {
+	switch input {
+	case "ycql":
+		return ybApi.YQLDatabase_YQL_DATABASE_CQL, true
+	case "ysql":
+		return ybApi.YQLDatabase_YQL_DATABASE_PGSQL, true
+	case "yedis":
+		return ybApi.YQLDatabase_YQL_DATABASE_REDIS, true
+	default:
+		return -1, false
+	}
+}
+
+func mapRelationTypeFilter(input string) (ybApi.RelationType, bool) {
+	switch input {
+	case "system_table":
+		return ybApi.RelationType_SYSTEM_TABLE_RELATION, true
+	case "user_table":
+		return ybApi.RelationType_USER_TABLE_RELATION, true
+	case "index":
+		return ybApi.RelationType_INDEX_TABLE_RELATION, true
+	default:
+		return -1, false
+	}
+}
+
+func pYQLDatabase(input ybApi.YQLDatabase) *ybApi.YQLDatabase {
+	return &input
 }

--- a/client/cli/common.go
+++ b/client/cli/common.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/radekg/yugabyte-db-go-client/configs"
+	"github.com/radekg/yugabyte-db-go-client/utils"
+	ybApi "github.com/radekg/yugabyte-db-go-proto/v2/yb/api"
+)
+
+func (c *defaultYBCliClient) getTableSchemaByUUID(tableID []byte) (*ybApi.GetTableSchemaResponsePB, error) {
+	payload := &ybApi.GetTableSchemaRequestPB{
+		Table: &ybApi.TableIdentifierPB{
+			TableId: tableID,
+		},
+	}
+	responsePayload := &ybApi.GetTableSchemaResponsePB{}
+	if err := c.connectedClient.Execute(payload, responsePayload); err != nil {
+		return nil, err
+	}
+	if err := responsePayload.GetError(); err != nil {
+		return nil, fmt.Errorf(err.String())
+	}
+	return responsePayload, nil
+}
+
+func (c *defaultYBCliClient) getTabletsForTableByUUID(tableID []byte, opConfig *configs.OpGetTableLocationsConfig) (*ybApi.GetTableLocationsResponsePB, error) {
+	payload := &ybApi.GetTableLocationsRequestPB{
+		Table: &ybApi.TableIdentifierPB{
+			TableId: tableID,
+		},
+		PartitionKeyStart:     opConfig.PartitionKeyStart,
+		PartitionKeyEnd:       opConfig.PartitionKeyEnd,
+		MaxReturnedLocations:  utils.PUint32(opConfig.MaxReturnedLocations),
+		RequireTabletsRunning: utils.PBool(opConfig.RequireTabletsRunning),
+	}
+	responsePayload := &ybApi.GetTableLocationsResponsePB{}
+	if err := c.connectedClient.Execute(payload, responsePayload); err != nil {
+		return nil, err
+	}
+	if err := responsePayload.GetError(); err != nil {
+		return nil, fmt.Errorf(err.String())
+	}
+	return responsePayload, nil
+}

--- a/client/cli/op_get_tablets_for_table.go
+++ b/client/cli/op_get_tablets_for_table.go
@@ -8,11 +8,11 @@ import (
 )
 
 // DescribeTable returns info on a table in this database.
-func (c *defaultYBCliClient) DescribeTable(opConfig *configs.OpGetTableSchemaConfig) (*ybApi.GetTableSchemaResponsePB, error) {
+func (c *defaultYBCliClient) GetTabletsForTable(opConfig *configs.OpGetTableLocationsConfig) (*ybApi.GetTableLocationsResponsePB, error) {
 
 	if opConfig.UUID != "" {
 		// we can short circuit everything below:
-		return c.getTableSchemaByUUID([]byte(opConfig.UUID))
+		return c.getTabletsForTableByUUID([]byte(opConfig.UUID), opConfig)
 	}
 
 	payloadListTables := &ybApi.ListTablesRequestPB{}
@@ -28,7 +28,7 @@ func (c *defaultYBCliClient) DescribeTable(opConfig *configs.OpGetTableSchemaCon
 		if tableInfo.Namespace != nil {
 			namespace := *tableInfo.Namespace
 			if *namespace.Name == opConfig.Keyspace && *tableInfo.Name == opConfig.Name {
-				return c.getTableSchemaByUUID(tableInfo.Id)
+				return c.getTabletsForTableByUUID(tableInfo.Id, opConfig)
 			}
 		}
 	}

--- a/client/cli/op_get_tablets_for_table.go
+++ b/client/cli/op_get_tablets_for_table.go
@@ -15,7 +15,10 @@ func (c *defaultYBCliClient) GetTabletsForTable(opConfig *configs.OpGetTableLoca
 		return c.getTabletsForTableByUUID([]byte(opConfig.UUID), opConfig)
 	}
 
-	payloadListTables := &ybApi.ListTablesRequestPB{}
+	parsedKeyspace := parseKeyspace(opConfig.Keyspace)
+	payloadListTables := &ybApi.ListTablesRequestPB{
+		Namespace: parsedKeyspace.toProtoKeyspace(),
+	}
 	responseListTablesPayload := &ybApi.ListTablesResponsePB{}
 	if err := c.connectedClient.Execute(payloadListTables, responseListTablesPayload); err != nil {
 		return nil, err
@@ -27,7 +30,7 @@ func (c *defaultYBCliClient) GetTabletsForTable(opConfig *configs.OpGetTableLoca
 	for _, tableInfo := range responseListTablesPayload.Tables {
 		if tableInfo.Namespace != nil {
 			namespace := *tableInfo.Namespace
-			if *namespace.Name == opConfig.Keyspace && *tableInfo.Name == opConfig.Name {
+			if *namespace.Name == parsedKeyspace.Keyspace && *tableInfo.Name == opConfig.Name {
 				return c.getTabletsForTableByUUID(tableInfo.Id, opConfig)
 			}
 		}

--- a/client/cli/op_list_tables.go
+++ b/client/cli/op_list_tables.go
@@ -16,19 +16,12 @@ func (c *defaultYBCliClient) ListTables(opConfig *configs.OpListTablesConfig) (*
 	if opConfig.NameFilter != "" {
 		payload.NameFilter = &opConfig.NameFilter
 	}
-	if opConfig.NamespaceName != "" || opConfig.NamespaceType != "" {
-		payload.Namespace = &ybApi.NamespaceIdentifierPB{
-			DatabaseType: pYQLDatabase(ybApi.YQLDatabase(ybApi.YQLDatabase_YQL_DATABASE_UNKNOWN)),
-		}
-		if opConfig.NamespaceName != "" {
-			payload.Namespace.Name = &opConfig.NamespaceName
-		}
-		if opConfig.NamespaceType != "" {
-			if yqlDatabaseType, ok := mapYQLDatabaseType(opConfig.NamespaceType); ok {
-				payload.Namespace.DatabaseType = pYQLDatabase(ybApi.YQLDatabase(yqlDatabaseType))
-			}
-		}
+
+	if opConfig.Keyspace != "" {
+		parsedKeyspace := parseKeyspace(opConfig.Keyspace)
+		payload.Namespace = parsedKeyspace.toProtoKeyspace()
 	}
+
 	if len(opConfig.RelationType) > 0 {
 		payload.RelationTypeFilter = []ybApi.RelationType{}
 		for _, relation := range opConfig.RelationType {
@@ -46,34 +39,4 @@ func (c *defaultYBCliClient) ListTables(opConfig *configs.OpListTablesConfig) (*
 		return nil, fmt.Errorf(err.String())
 	}
 	return responsePayload, nil
-}
-
-func mapYQLDatabaseType(input string) (ybApi.YQLDatabase, bool) {
-	switch input {
-	case "cql":
-		return ybApi.YQLDatabase_YQL_DATABASE_CQL, true
-	case "pgsql":
-		return ybApi.YQLDatabase_YQL_DATABASE_PGSQL, true
-	case "redis":
-		return ybApi.YQLDatabase_YQL_DATABASE_REDIS, true
-	default:
-		return -1, false
-	}
-}
-
-func mapRelationTypeFilter(input string) (ybApi.RelationType, bool) {
-	switch input {
-	case "system_table":
-		return ybApi.RelationType_SYSTEM_TABLE_RELATION, true
-	case "user_table":
-		return ybApi.RelationType_USER_TABLE_RELATION, true
-	case "index":
-		return ybApi.RelationType_INDEX_TABLE_RELATION, true
-	default:
-		return -1, false
-	}
-}
-
-func pYQLDatabase(input ybApi.YQLDatabase) *ybApi.YQLDatabase {
-	return &input
 }

--- a/cmd/gettabletsfortable/cmd.go
+++ b/cmd/gettabletsfortable/cmd.go
@@ -1,4 +1,4 @@
-package describetable
+package gettabletsfortable
 
 import (
 	"encoding/json"
@@ -12,8 +12,8 @@ import (
 
 // Command is the command declaration.
 var Command = &cobra.Command{
-	Use:   "describe-table",
-	Short: "Info on a table in this database",
+	Use:   "get-tablets-for-table",
+	Short: "Get table locations",
 	Run:   run,
 	Long:  ``,
 }
@@ -21,7 +21,7 @@ var Command = &cobra.Command{
 var (
 	commandConfig = configs.NewCliConfig()
 	logConfig     = configs.NewLogginConfig()
-	opConfig      = configs.NewOpGetTableSchemaConfig()
+	opConfig      = configs.NewOpGetTableLocationsConfig()
 )
 
 func initFlags() {
@@ -40,7 +40,7 @@ func run(cobraCommand *cobra.Command, _ []string) {
 
 func processCommand() int {
 
-	logger := logConfig.NewLogger("describe-table")
+	logger := logConfig.NewLogger("get-tablets-for-table")
 
 	for _, validatingConfig := range []configs.ValidatingConfig{commandConfig, opConfig} {
 		if err := validatingConfig.Validate(); err != nil {
@@ -68,11 +68,11 @@ func processCommand() int {
 	}
 	defer cliClient.Close()
 
-	responsePayload, err := cliClient.DescribeTable(opConfig)
+	responsePayload, err := cliClient.GetTabletsForTable(opConfig)
 	if err != nil {
 		// if not found, handle an error:
 		// code:OBJECT_NOT_FOUND status:{code:NOT_FOUND message:"Table with identifier  not found: OBJECT_NOT_FOUND" source_file:"../../src/yb/master/catalog_manager.cc" source_line:3803 errors:"\t\x03\x00\x00\x00\x00"}
-		logger.Error("failed reading describe table response", "reason", err)
+		logger.Error("failed reading response", "reason", err)
 		return 1
 	}
 

--- a/configs/common.go
+++ b/configs/common.go
@@ -36,7 +36,7 @@ func NewCliConfig() *CliConfig {
 func (c *CliConfig) FlagSet() *pflag.FlagSet {
 	if c.initFlagSet() {
 		c.flagSet.StringVar(&c.MasterHostPort, "master", "127.0.0.1:7100", "Master host port")
-		c.flagSet.DurationVar(&c.OpTimeout, "operation-timeout", time.Duration(time.Second*5), "Operation timeout")
+		c.flagSet.DurationVar(&c.OpTimeout, "operation-timeout", time.Duration(time.Second*60), "Operation timeout")
 		c.flagSet.StringVar(&c.TLSCaCertFilePath, "tls-ca-cert-file-path", "", "TLS CA certificate file path")
 		c.flagSet.StringVar(&c.TLSCertFilePath, "tls-cert-file-path", "", "TLS certificate file path")
 		c.flagSet.StringVar(&c.TLSKeyFilePath, "tls-key-file-path", "", "TLS key file path")

--- a/configs/op_configs.go
+++ b/configs/op_configs.go
@@ -93,7 +93,7 @@ func (c *OpGetTableSchemaConfig) Validate() error {
 // ==
 
 var (
-	supportedNamespaceType = []string{"cql", "pgsql", "redis"}
+	supportedNamespaceType = []string{"ycql", "ysql", "yedis"}
 	supportedRelationType  = []string{"system_table", "user_table", "index"}
 )
 
@@ -102,8 +102,7 @@ type OpListTablesConfig struct {
 	flagBase
 
 	NameFilter          string
-	NamespaceName       string
-	NamespaceType       string
+	Keyspace            string
 	ExcludeSystemTables bool
 	IncludeNotRunning   bool
 	RelationType        []string
@@ -118,8 +117,7 @@ func NewOpListTablesConfig() *OpListTablesConfig {
 func (c *OpListTablesConfig) FlagSet() *pflag.FlagSet {
 	if c.initFlagSet() {
 		c.flagSet.StringVar(&c.NameFilter, "name-filter", "", "When used, only returns tables that satisfy a substring match on name_filter")
-		c.flagSet.StringVar(&c.NamespaceName, "keyspace", "", "The namespace name to fetch info")
-		c.flagSet.StringVar(&c.NamespaceType, "namespace-type", "", fmt.Sprintf("Database type: %s", strings.Join(supportedNamespaceType, ", ")))
+		c.flagSet.StringVar(&c.Keyspace, "keyspace", "", "The namespace name to fetch info")
 		c.flagSet.BoolVar(&c.ExcludeSystemTables, "exclude-system-tables", false, "Exclude system tables")
 		c.flagSet.BoolVar(&c.IncludeNotRunning, "include-not-running", false, "Include not running")
 		c.flagSet.StringSliceVar(&c.RelationType, "relation-type", supportedRelationType, fmt.Sprintf("Filter tables based on RelationType: %s", strings.Join(supportedRelationType, ", ")))
@@ -129,18 +127,6 @@ func (c *OpListTablesConfig) FlagSet() *pflag.FlagSet {
 
 // Validate validates the correctness of the configuration.
 func (c *OpListTablesConfig) Validate() error {
-	if c.NamespaceType != "" {
-		var found bool
-		for _, opt := range supportedNamespaceType {
-			if opt == c.NamespaceType {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return fmt.Errorf("unsupported value '%s' for --namespace-type", c.NamespaceType)
-		}
-	}
 	for _, relation := range c.RelationType {
 		var found bool
 		for _, opt := range supportedRelationType {

--- a/configs/op_configs.go
+++ b/configs/op_configs.go
@@ -7,6 +7,54 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// OpGetTableLocationsConfig represents a command specific config.
+type OpGetTableLocationsConfig struct {
+	flagBase
+
+	Keyspace string
+	Name     string
+	UUID     string
+
+	PartitionKeyStart     []byte
+	PartitionKeyEnd       []byte
+	MaxReturnedLocations  uint32
+	RequireTabletsRunning bool
+}
+
+// NewOpGetTableLocationsConfig returns an instance of the command specific config.
+func NewOpGetTableLocationsConfig() *OpGetTableLocationsConfig {
+	return &OpGetTableLocationsConfig{
+		MaxReturnedLocations: uint32(10),
+	}
+}
+
+// FlagSet returns an instance of the flag set for the configuration.
+func (c *OpGetTableLocationsConfig) FlagSet() *pflag.FlagSet {
+	if c.initFlagSet() {
+		c.flagSet.StringVar(&c.Keyspace, "keyspace", "", "Keyspace to check in")
+		c.flagSet.StringVar(&c.Name, "name", "", "Table name to check for")
+		c.flagSet.StringVar(&c.UUID, "uuid", "", "Table identifier to check for")
+		c.flagSet.BytesBase64Var(&c.PartitionKeyStart, "partition-key-start", []byte{}, "Partition key range start")
+		c.flagSet.BytesBase64Var(&c.PartitionKeyEnd, "partition-key-end", []byte{}, "Partition key range end")
+		c.flagSet.Uint32Var(&c.MaxReturnedLocations, "max-returned-locations", 10, "Maximum number of returned locations")
+		c.flagSet.BoolVar(&c.RequireTabletsRunning, "require-tablet-running", false, "Require tablet running")
+	}
+	return c.flagSet
+}
+
+// Validate validates the correctness of the configuration.
+func (c *OpGetTableLocationsConfig) Validate() error {
+	if c.Name != "" && c.Keyspace == "" {
+		return fmt.Errorf("--keyspace is required when --name is given")
+	}
+	if c.Name == "" && c.UUID == "" {
+		return fmt.Errorf("--name or --uuid is required")
+	}
+	return nil
+}
+
+// ==
+
 // OpGetTableSchemaConfig represents a command specific config.
 type OpGetTableSchemaConfig struct {
 	flagBase

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/radekg/yugabyte-db-go-client/cmd/describetable"
 	"github.com/radekg/yugabyte-db-go-client/cmd/getloadmovecompletion"
 	"github.com/radekg/yugabyte-db-go-client/cmd/getmasterregistration"
+	"github.com/radekg/yugabyte-db-go-client/cmd/gettabletsfortable"
 	"github.com/radekg/yugabyte-db-go-client/cmd/getuniverseconfig"
 	"github.com/radekg/yugabyte-db-go-client/cmd/isloadbalanced"
 	"github.com/radekg/yugabyte-db-go-client/cmd/isserverready"
@@ -36,6 +37,7 @@ func init() {
 	rootCmd.AddCommand(describetable.Command)
 	rootCmd.AddCommand(getloadmovecompletion.Command)
 	rootCmd.AddCommand(getmasterregistration.Command)
+	rootCmd.AddCommand(gettabletsfortable.Command)
 	rootCmd.AddCommand(getuniverseconfig.Command)
 	rootCmd.AddCommand(isloadbalanced.Command)
 	rootCmd.AddCommand(isserverready.Command)


### PR DESCRIPTION
This PR introduces `get-tablets-for-table` CLI call and changes how `--keyspace` flag is treated. Keyspace can now be prefixed with one of: `ycql.`, `ysql.`, or `yedis.` to indicate which YQL database type we are intending to use.

This PR also resizes the minimal cluster to handle a replication factor of `3`.