### PR TITLE
Add multi-host-port master leader discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Work in progress. Current state: this can definitely work.
 
 ### Usage
 
-The `github.com/radekg/yugabyte-db-go-client/client/cli` provides a reference client implementation.
+The `github.com/radekg/yugabyte-db-go-client/client/implementation` provides a reference client implementation.
 
 **TL;DR**: here's how to use the API client directly from _go_:
 
@@ -135,7 +135,7 @@ where the command is one of:
 
 Common flags:
 
-- `--master`: host port of the master to query, default `127.0.0.1:7100`
+- `--master`: string, repeated, host port of the master to query, default `127.0.0.1:7100, 127.0.0.1:7101, 127.0.0.1:7102`
 - `--operation-timeout`: RPC operation timeout, duration string (`5s`, `1m`, ...), default `60s`
 - `--tls-ca-cert-file-path`: full path to the CA certificate file, default `empty string`
 - `--tls-cert-file-path`: full path to the certificate file, default `empty string`

--- a/client/implementation/cli_client.go
+++ b/client/implementation/cli_client.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	"github.com/hashicorp/go-hclog"

--- a/client/implementation/cli_master_leader_client.go
+++ b/client/implementation/cli_master_leader_client.go
@@ -1,0 +1,101 @@
+package implementation
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/radekg/yugabyte-db-go-client/configs"
+
+	ybApi "github.com/radekg/yugabyte-db-go-proto/v2/yb/api"
+)
+
+// MasterLeaderConnectedClient creates a client for every configured master host port and tests each one for
+// the leader status. First client for whom the relevant master server returns Raft peer role: Leader
+// if returned to the caller.
+// If no master leader can be found or all clients experienced a connection error, an error is returned
+// to the caller.
+func MasterLeaderConnectedClient(commandConfig *configs.CliConfig, logger hclog.Logger) (YBCliClient, error) {
+
+	validConfigs := map[string]*configs.YBClientConfig{}
+	for _, hostPort := range commandConfig.MasterHostPort {
+		cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(hostPort, commandConfig)
+		if cliConfigErr != nil {
+			logger.Error("failed creating client configuration, skipping",
+				"reason", cliConfigErr,
+				"host-port", hostPort)
+			continue
+		}
+		validConfigs[hostPort] = cliConfig
+	}
+
+	chanConnectedClient := make(chan YBCliClient, 1)
+	chanErrors := make(chan error)
+
+	for hostPort, cliConfig := range validConfigs {
+		go func(thisHostPort string, thisConfig *configs.YBClientConfig) {
+			cliClient, err := NewYBConnectedClient(thisConfig, logger.Named("client"))
+			if err != nil {
+				logger.Error("failed creating a client",
+					"reason", err,
+					"host-port", thisHostPort)
+				chanErrors <- err
+				return
+			}
+
+			select {
+			case err := <-cliClient.OnConnectError():
+
+				logger.Error("connection error",
+					"reason", err,
+					"host-port", thisHostPort)
+				cliClient.Close()
+				chanErrors <- err
+
+			case <-cliClient.OnConnected():
+
+				masterRegistration, err := cliClient.GetMasterRegistration()
+
+				if err != nil {
+					logger.Error("failed querying master registration",
+						"reason", err,
+						"host-port", thisHostPort)
+					cliClient.Close()
+					chanErrors <- err
+					return
+				}
+
+				if *masterRegistration.Role != ybApi.RaftPeerPB_LEADER {
+					logger.Trace("master not leader",
+						"host-port", thisHostPort)
+					cliClient.Close()
+					chanErrors <- fmt.Errorf("master %s not leader", thisHostPort)
+					return
+				}
+
+				logger.Info("found master leader", "host-port", thisHostPort)
+				chanConnectedClient <- cliClient
+			}
+
+		}(hostPort, cliConfig)
+	}
+
+	var done uint64
+	max := uint64(len(validConfigs))
+
+	for {
+		select {
+		case <-chanErrors:
+			atomic.AddUint64(&done, 1)
+			if atomic.LoadUint64(&done) == max {
+				return nil, fmt.Errorf("no reachable leaders")
+			}
+		case connectedClient := <-chanConnectedClient:
+			return connectedClient, nil
+		case <-time.After(commandConfig.OpTimeout):
+			return nil, fmt.Errorf("failed to connect to a leader master within timeout")
+		}
+	}
+
+}

--- a/client/implementation/common.go
+++ b/client/implementation/common.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	"fmt"

--- a/client/implementation/op_check_exists.go
+++ b/client/implementation/op_check_exists.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	"github.com/radekg/yugabyte-db-go-client/configs"

--- a/client/implementation/op_describe_table.go
+++ b/client/implementation/op_describe_table.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	"github.com/radekg/yugabyte-db-go-client/configs"

--- a/client/implementation/op_get_load_move_completion.go
+++ b/client/implementation/op_get_load_move_completion.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	ybApi "github.com/radekg/yugabyte-db-go-proto/v2/yb/api"

--- a/client/implementation/op_get_master_registration.go
+++ b/client/implementation/op_get_master_registration.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	ybApi "github.com/radekg/yugabyte-db-go-proto/v2/yb/api"

--- a/client/implementation/op_get_tablets_for_table.go
+++ b/client/implementation/op_get_tablets_for_table.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	"fmt"

--- a/client/implementation/op_get_universe_config.go
+++ b/client/implementation/op_get_universe_config.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	ybApi "github.com/radekg/yugabyte-db-go-proto/v2/yb/api"

--- a/client/implementation/op_is_load_balanced.go
+++ b/client/implementation/op_is_load_balanced.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	"github.com/radekg/yugabyte-db-go-client/configs"

--- a/client/implementation/op_is_tablet_server_ready.go
+++ b/client/implementation/op_is_tablet_server_ready.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import ybApi "github.com/radekg/yugabyte-db-go-proto/v2/yb/api"
 

--- a/client/implementation/op_leader_step_down.go
+++ b/client/implementation/op_leader_step_down.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	"github.com/radekg/yugabyte-db-go-client/configs"

--- a/client/implementation/op_list_masters.go
+++ b/client/implementation/op_list_masters.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	ybApi "github.com/radekg/yugabyte-db-go-proto/v2/yb/api"

--- a/client/implementation/op_list_tables.go
+++ b/client/implementation/op_list_tables.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	"github.com/radekg/yugabyte-db-go-client/configs"

--- a/client/implementation/op_list_tablet_servers.go
+++ b/client/implementation/op_list_tablet_servers.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	"github.com/radekg/yugabyte-db-go-client/configs"

--- a/client/implementation/op_master_leader_step_down.go
+++ b/client/implementation/op_master_leader_step_down.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	"fmt"

--- a/client/implementation/op_ping.go
+++ b/client/implementation/op_ping.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import ybApi "github.com/radekg/yugabyte-db-go-proto/v2/yb/api"
 

--- a/client/implementation/op_set_load_balancer_state.go
+++ b/client/implementation/op_set_load_balancer_state.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	"github.com/radekg/yugabyte-db-go-client/utils"

--- a/client/implementation/op_snapshots_create.go
+++ b/client/implementation/op_snapshots_create.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	"fmt"

--- a/client/implementation/op_snapshots_create_schedule.go
+++ b/client/implementation/op_snapshots_create_schedule.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	"github.com/radekg/yugabyte-db-go-client/configs"

--- a/client/implementation/op_snapshots_delete.go
+++ b/client/implementation/op_snapshots_delete.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	"github.com/radekg/yugabyte-db-go-client/configs"

--- a/client/implementation/op_snapshots_delete_schedule.go
+++ b/client/implementation/op_snapshots_delete_schedule.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	"github.com/radekg/yugabyte-db-go-client/configs"

--- a/client/implementation/op_snapshots_export.go
+++ b/client/implementation/op_snapshots_export.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	"fmt"

--- a/client/implementation/op_snapshots_import.go
+++ b/client/implementation/op_snapshots_import.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	"fmt"

--- a/client/implementation/op_snapshots_list.go
+++ b/client/implementation/op_snapshots_list.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	"github.com/radekg/yugabyte-db-go-client/configs"

--- a/client/implementation/op_snapshots_list_schedules.go
+++ b/client/implementation/op_snapshots_list_schedules.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	"github.com/radekg/yugabyte-db-go-client/configs"

--- a/client/implementation/op_snapshots_restore.go
+++ b/client/implementation/op_snapshots_restore.go
@@ -1,4 +1,4 @@
-package cli
+package implementation
 
 import (
 	"github.com/radekg/yugabyte-db-go-client/configs"

--- a/cmd/checkexists/cmd.go
+++ b/cmd/checkexists/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -49,23 +49,7 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
-	if cliConfigErr != nil {
-		logger.Error("failed creating client configuration", "reason", cliConfigErr)
-		return 1
-	}
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
-	if err != nil {
-		logger.Error("failed creating a client", "reason", err)
-		return 1
-	}
-	select {
-	case err := <-cliClient.OnConnectError():
-		logger.Error("failed connecting a client", "reason", err)
-		return 1
-	case <-cliClient.OnConnected():
-		logger.Debug("client connected")
-	}
+	cliClient, err := implementation.MasterLeaderConnectedClient(commandConfig, logger.Named("client"))
 	defer cliClient.Close()
 
 	responsePayload, err := cliClient.CheckExists(opConfig)

--- a/cmd/describetable/cmd.go
+++ b/cmd/describetable/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -49,23 +49,7 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
-	if cliConfigErr != nil {
-		logger.Error("failed creating client configuration", "reason", cliConfigErr)
-		return 1
-	}
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
-	if err != nil {
-		logger.Error("failed creating a client", "reason", err)
-		return 1
-	}
-	select {
-	case err := <-cliClient.OnConnectError():
-		logger.Error("failed connecting a client", "reason", err)
-		return 1
-	case <-cliClient.OnConnected():
-		logger.Debug("client connected")
-	}
+	cliClient, err := implementation.MasterLeaderConnectedClient(commandConfig, logger.Named("client"))
 	defer cliClient.Close()
 
 	responsePayload, err := cliClient.DescribeTable(opConfig)

--- a/cmd/getloadmovecompletion/cmd.go
+++ b/cmd/getloadmovecompletion/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -47,23 +47,7 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
-	if cliConfigErr != nil {
-		logger.Error("failed creating client configuration", "reason", cliConfigErr)
-		return 1
-	}
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
-	if err != nil {
-		logger.Error("failed creating a client", "reason", err)
-		return 1
-	}
-	select {
-	case err := <-cliClient.OnConnectError():
-		logger.Error("failed connecting a client", "reason", err)
-		return 1
-	case <-cliClient.OnConnected():
-		logger.Debug("client connected")
-	}
+	cliClient, err := implementation.MasterLeaderConnectedClient(commandConfig, logger.Named("client"))
 	defer cliClient.Close()
 
 	registration, err := cliClient.GetLoadMoveCompletion()

--- a/cmd/getmasterregistration/cmd.go
+++ b/cmd/getmasterregistration/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -47,23 +47,7 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
-	if cliConfigErr != nil {
-		logger.Error("failed creating client configuration", "reason", cliConfigErr)
-		return 1
-	}
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
-	if err != nil {
-		logger.Error("failed creating a client", "reason", err)
-		return 1
-	}
-	select {
-	case err := <-cliClient.OnConnectError():
-		logger.Error("failed connecting a client", "reason", err)
-		return 1
-	case <-cliClient.OnConnected():
-		logger.Debug("client connected")
-	}
+	cliClient, err := implementation.MasterLeaderConnectedClient(commandConfig, logger.Named("client"))
 	defer cliClient.Close()
 
 	registration, err := cliClient.GetMasterRegistration()

--- a/cmd/gettabletsfortable/cmd.go
+++ b/cmd/gettabletsfortable/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -49,23 +49,7 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
-	if cliConfigErr != nil {
-		logger.Error("failed creating client configuration", "reason", cliConfigErr)
-		return 1
-	}
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
-	if err != nil {
-		logger.Error("failed creating a client", "reason", err)
-		return 1
-	}
-	select {
-	case err := <-cliClient.OnConnectError():
-		logger.Error("failed connecting a client", "reason", err)
-		return 1
-	case <-cliClient.OnConnected():
-		logger.Debug("client connected")
-	}
+	cliClient, err := implementation.MasterLeaderConnectedClient(commandConfig, logger.Named("client"))
 	defer cliClient.Close()
 
 	responsePayload, err := cliClient.GetTabletsForTable(opConfig)

--- a/cmd/getuniverseconfig/cmd.go
+++ b/cmd/getuniverseconfig/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -47,23 +47,7 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
-	if cliConfigErr != nil {
-		logger.Error("failed creating client configuration", "reason", cliConfigErr)
-		return 1
-	}
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
-	if err != nil {
-		logger.Error("failed creating a client", "reason", err)
-		return 1
-	}
-	select {
-	case err := <-cliClient.OnConnectError():
-		logger.Error("failed connecting a client", "reason", err)
-		return 1
-	case <-cliClient.OnConnected():
-		logger.Debug("client connected")
-	}
+	cliClient, err := implementation.MasterLeaderConnectedClient(commandConfig, logger.Named("client"))
 	defer cliClient.Close()
 
 	registration, err := cliClient.GetUniverseConfig()

--- a/cmd/isloadbalanced/cmd.go
+++ b/cmd/isloadbalanced/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -49,23 +49,7 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
-	if cliConfigErr != nil {
-		logger.Error("failed creating client configuration", "reason", cliConfigErr)
-		return 1
-	}
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
-	if err != nil {
-		logger.Error("failed creating a client", "reason", err)
-		return 1
-	}
-	select {
-	case err := <-cliClient.OnConnectError():
-		logger.Error("failed connecting a client", "reason", err)
-		return 1
-	case <-cliClient.OnConnected():
-		logger.Debug("client connected")
-	}
+	cliClient, err := implementation.MasterLeaderConnectedClient(commandConfig, logger.Named("client"))
 	defer cliClient.Close()
 
 	responsePayload, err := cliClient.IsLoadBalanced(opConfig)

--- a/cmd/isserverready/cmd.go
+++ b/cmd/isserverready/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -49,14 +49,14 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
+	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig.MasterHostPort[0], commandConfig)
 	if cliConfigErr != nil {
 		logger.Error("failed creating client configuration", "reason", cliConfigErr)
 		return 1
 	}
 	cliConfig.MasterHostPort = fmt.Sprintf("%s:%d", opConfig.Host, opConfig.Port)
 	// TODO: REVISIT: what's the is-tserver flag for?
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
+	cliClient, err := implementation.NewYBConnectedClient(cliConfig, logger.Named("client"))
 	if err != nil {
 		// careful: different than other commands:
 		logger.Error("server not reachable", "reason", err)

--- a/cmd/leaderstepdown/cmd.go
+++ b/cmd/leaderstepdown/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -49,23 +49,7 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
-	if cliConfigErr != nil {
-		logger.Error("failed creating client configuration", "reason", cliConfigErr)
-		return 1
-	}
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
-	if err != nil {
-		logger.Error("failed creating a client", "reason", err)
-		return 1
-	}
-	select {
-	case err := <-cliClient.OnConnectError():
-		logger.Error("failed connecting a client", "reason", err)
-		return 1
-	case <-cliClient.OnConnected():
-		logger.Debug("client connected")
-	}
+	cliClient, err := implementation.MasterLeaderConnectedClient(commandConfig, logger.Named("client"))
 	defer cliClient.Close()
 
 	responsePayload, err := cliClient.LeaderStepDown(opConfig)

--- a/cmd/listmasters/cmd.go
+++ b/cmd/listmasters/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -47,23 +47,7 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
-	if cliConfigErr != nil {
-		logger.Error("failed creating client configuration", "reason", cliConfigErr)
-		return 1
-	}
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
-	if err != nil {
-		logger.Error("failed creating a client", "reason", err)
-		return 1
-	}
-	select {
-	case err := <-cliClient.OnConnectError():
-		logger.Error("failed connecting a client", "reason", err)
-		return 1
-	case <-cliClient.OnConnected():
-		logger.Debug("client connected")
-	}
+	cliClient, err := implementation.MasterLeaderConnectedClient(commandConfig, logger.Named("client"))
 	defer cliClient.Close()
 
 	responsePayload, err := cliClient.ListMasters()

--- a/cmd/listtables/cmd.go
+++ b/cmd/listtables/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -49,23 +49,7 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
-	if cliConfigErr != nil {
-		logger.Error("failed creating client configuration", "reason", cliConfigErr)
-		return 1
-	}
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
-	if err != nil {
-		logger.Error("failed creating a client", "reason", err)
-		return 1
-	}
-	select {
-	case err := <-cliClient.OnConnectError():
-		logger.Error("failed connecting a client", "reason", err)
-		return 1
-	case <-cliClient.OnConnected():
-		logger.Debug("client connected")
-	}
+	cliClient, err := implementation.MasterLeaderConnectedClient(commandConfig, logger.Named("client"))
 	defer cliClient.Close()
 
 	responsePayload, err := cliClient.ListTables(opConfig)

--- a/cmd/listtabletservers/cmd.go
+++ b/cmd/listtabletservers/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -49,23 +49,7 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
-	if cliConfigErr != nil {
-		logger.Error("failed creating client configuration", "reason", cliConfigErr)
-		return 1
-	}
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
-	if err != nil {
-		logger.Error("failed creating a client", "reason", err)
-		return 1
-	}
-	select {
-	case err := <-cliClient.OnConnectError():
-		logger.Error("failed connecting a client", "reason", err)
-		return 1
-	case <-cliClient.OnConnected():
-		logger.Debug("client connected")
-	}
+	cliClient, err := implementation.MasterLeaderConnectedClient(commandConfig, logger.Named("client"))
 	defer cliClient.Close()
 
 	responsePayload, err := cliClient.ListTabletServers(opConfig)

--- a/cmd/masterleaderstepdown/cmd.go
+++ b/cmd/masterleaderstepdown/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -47,23 +47,7 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
-	if cliConfigErr != nil {
-		logger.Error("failed creating client configuration", "reason", cliConfigErr)
-		return 1
-	}
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
-	if err != nil {
-		logger.Error("failed creating a client", "reason", err)
-		return 1
-	}
-	select {
-	case err := <-cliClient.OnConnectError():
-		logger.Error("failed connecting a client", "reason", err)
-		return 1
-	case <-cliClient.OnConnected():
-		logger.Debug("client connected")
-	}
+	cliClient, err := implementation.MasterLeaderConnectedClient(commandConfig, logger.Named("client"))
 	defer cliClient.Close()
 
 	responsePayload, err := cliClient.MasterLeaderStepDown()

--- a/cmd/ping/cmd.go
+++ b/cmd/ping/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -49,13 +49,13 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
+	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig.MasterHostPort[0], commandConfig)
 	if cliConfigErr != nil {
 		logger.Error("failed creating client configuration", "reason", cliConfigErr)
 		return 1
 	}
 	cliConfig.MasterHostPort = fmt.Sprintf("%s:%d", opConfig.Host, opConfig.Port)
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
+	cliClient, err := implementation.NewYBConnectedClient(cliConfig, logger.Named("client"))
 	if err != nil {
 		// careful: different than other commands:
 		logger.Error("server not reachable", "reason", err)

--- a/cmd/setloadbalancerstate/cmd.go
+++ b/cmd/setloadbalancerstate/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -55,23 +55,7 @@ func processCommand() int {
 		return 1
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
-	if cliConfigErr != nil {
-		logger.Error("failed creating client configuration", "reason", cliConfigErr)
-		return 1
-	}
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
-	if err != nil {
-		logger.Error("failed creating a client", "reason", err)
-		return 1
-	}
-	select {
-	case err := <-cliClient.OnConnectError():
-		logger.Error("failed connecting a client", "reason", err)
-		return 1
-	case <-cliClient.OnConnected():
-		logger.Debug("client connected")
-	}
+	cliClient, err := implementation.MasterLeaderConnectedClient(commandConfig, logger.Named("client"))
 	defer cliClient.Close()
 
 	responsePayload, err := cliClient.SetLoadBalancerState(boolState)

--- a/cmd/snapshots/create/cmd.go
+++ b/cmd/snapshots/create/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -49,23 +49,7 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
-	if cliConfigErr != nil {
-		logger.Error("failed creating client configuration", "reason", cliConfigErr)
-		return 1
-	}
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
-	if err != nil {
-		logger.Error("failed creating a client", "reason", err)
-		return 1
-	}
-	select {
-	case err := <-cliClient.OnConnectError():
-		logger.Error("failed connecting a client", "reason", err)
-		return 1
-	case <-cliClient.OnConnected():
-		logger.Debug("client connected")
-	}
+	cliClient, err := implementation.MasterLeaderConnectedClient(commandConfig, logger.Named("client"))
 	defer cliClient.Close()
 
 	responsePayload, err := cliClient.SnapshotsCreate(opConfig)

--- a/cmd/snapshots/createschedule/cmd.go
+++ b/cmd/snapshots/createschedule/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -49,23 +49,7 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
-	if cliConfigErr != nil {
-		logger.Error("failed creating client configuration", "reason", cliConfigErr)
-		return 1
-	}
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
-	if err != nil {
-		logger.Error("failed creating a client", "reason", err)
-		return 1
-	}
-	select {
-	case err := <-cliClient.OnConnectError():
-		logger.Error("failed connecting a client", "reason", err)
-		return 1
-	case <-cliClient.OnConnected():
-		logger.Debug("client connected")
-	}
+	cliClient, err := implementation.MasterLeaderConnectedClient(commandConfig, logger.Named("client"))
 	defer cliClient.Close()
 
 	responsePayload, err := cliClient.SnapshotsCreateSchedule(opConfig)

--- a/cmd/snapshots/delete/cmd.go
+++ b/cmd/snapshots/delete/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -49,23 +49,7 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
-	if cliConfigErr != nil {
-		logger.Error("failed creating client configuration", "reason", cliConfigErr)
-		return 1
-	}
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
-	if err != nil {
-		logger.Error("failed creating a client", "reason", err)
-		return 1
-	}
-	select {
-	case err := <-cliClient.OnConnectError():
-		logger.Error("failed connecting a client", "reason", err)
-		return 1
-	case <-cliClient.OnConnected():
-		logger.Debug("client connected")
-	}
+	cliClient, err := implementation.MasterLeaderConnectedClient(commandConfig, logger.Named("client"))
 	defer cliClient.Close()
 
 	responsePayload, err := cliClient.SnapshotsDelete(opConfig)

--- a/cmd/snapshots/deleteschedule/cmd.go
+++ b/cmd/snapshots/deleteschedule/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -49,23 +49,7 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
-	if cliConfigErr != nil {
-		logger.Error("failed creating client configuration", "reason", cliConfigErr)
-		return 1
-	}
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
-	if err != nil {
-		logger.Error("failed creating a client", "reason", err)
-		return 1
-	}
-	select {
-	case err := <-cliClient.OnConnectError():
-		logger.Error("failed connecting a client", "reason", err)
-		return 1
-	case <-cliClient.OnConnected():
-		logger.Debug("client connected")
-	}
+	cliClient, err := implementation.MasterLeaderConnectedClient(commandConfig, logger.Named("client"))
 	defer cliClient.Close()
 
 	responsePayload, err := cliClient.SnapshotsDeleteSchedule(opConfig)

--- a/cmd/snapshots/export/cmd.go
+++ b/cmd/snapshots/export/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -49,23 +49,7 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
-	if cliConfigErr != nil {
-		logger.Error("failed creating client configuration", "reason", cliConfigErr)
-		return 1
-	}
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
-	if err != nil {
-		logger.Error("failed creating a client", "reason", err)
-		return 1
-	}
-	select {
-	case err := <-cliClient.OnConnectError():
-		logger.Error("failed connecting a client", "reason", err)
-		return 1
-	case <-cliClient.OnConnected():
-		logger.Debug("client connected")
-	}
+	cliClient, err := implementation.MasterLeaderConnectedClient(commandConfig, logger.Named("client"))
 	defer cliClient.Close()
 
 	responsePayload, err := cliClient.SnapshotsExport(opConfig)

--- a/cmd/snapshots/import/cmd.go
+++ b/cmd/snapshots/import/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -49,23 +49,7 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
-	if cliConfigErr != nil {
-		logger.Error("failed creating client configuration", "reason", cliConfigErr)
-		return 1
-	}
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
-	if err != nil {
-		logger.Error("failed creating a client", "reason", err)
-		return 1
-	}
-	select {
-	case err := <-cliClient.OnConnectError():
-		logger.Error("failed connecting a client", "reason", err)
-		return 1
-	case <-cliClient.OnConnected():
-		logger.Debug("client connected")
-	}
+	cliClient, err := implementation.MasterLeaderConnectedClient(commandConfig, logger.Named("client"))
 	defer cliClient.Close()
 
 	responsePayload, err := cliClient.SnapshotsImport(opConfig)

--- a/cmd/snapshots/list/cmd.go
+++ b/cmd/snapshots/list/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -49,23 +49,7 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
-	if cliConfigErr != nil {
-		logger.Error("failed creating client configuration", "reason", cliConfigErr)
-		return 1
-	}
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
-	if err != nil {
-		logger.Error("failed creating a client", "reason", err)
-		return 1
-	}
-	select {
-	case err := <-cliClient.OnConnectError():
-		logger.Error("failed connecting a client", "reason", err)
-		return 1
-	case <-cliClient.OnConnected():
-		logger.Debug("client connected")
-	}
+	cliClient, err := implementation.MasterLeaderConnectedClient(commandConfig, logger.Named("client"))
 	defer cliClient.Close()
 
 	responsePayload, err := cliClient.SnapshotsList(opConfig)

--- a/cmd/snapshots/listschedules/cmd.go
+++ b/cmd/snapshots/listschedules/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -49,23 +49,7 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
-	if cliConfigErr != nil {
-		logger.Error("failed creating client configuration", "reason", cliConfigErr)
-		return 1
-	}
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
-	if err != nil {
-		logger.Error("failed creating a client", "reason", err)
-		return 1
-	}
-	select {
-	case err := <-cliClient.OnConnectError():
-		logger.Error("failed connecting a client", "reason", err)
-		return 1
-	case <-cliClient.OnConnected():
-		logger.Debug("client connected")
-	}
+	cliClient, err := implementation.MasterLeaderConnectedClient(commandConfig, logger.Named("client"))
 	defer cliClient.Close()
 
 	responsePayload, err := cliClient.SnapshotsListSchedules(opConfig)

--- a/cmd/snapshots/restore/cmd.go
+++ b/cmd/snapshots/restore/cmd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/radekg/yugabyte-db-go-client/client/cli"
+	"github.com/radekg/yugabyte-db-go-client/client/implementation"
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/spf13/cobra"
 )
@@ -49,23 +49,7 @@ func processCommand() int {
 		}
 	}
 
-	cliConfig, cliConfigErr := configs.NewYBClientConfigFromCliConfig(commandConfig)
-	if cliConfigErr != nil {
-		logger.Error("failed creating client configuration", "reason", cliConfigErr)
-		return 1
-	}
-	cliClient, err := cli.NewYBConnectedClient(cliConfig, logger.Named("client"))
-	if err != nil {
-		logger.Error("failed creating a client", "reason", err)
-		return 1
-	}
-	select {
-	case err := <-cliClient.OnConnectError():
-		logger.Error("failed connecting a client", "reason", err)
-		return 1
-	case <-cliClient.OnConnected():
-		logger.Debug("client connected")
-	}
+	cliClient, err := implementation.MasterLeaderConnectedClient(commandConfig, logger.Named("client"))
 	defer cliClient.Close()
 
 	responsePayload, err := cliClient.SnapshotsRestore(opConfig)

--- a/configs/common.go
+++ b/configs/common.go
@@ -20,7 +20,7 @@ type CliConfig struct {
 	flagBase
 	tlsConfig *tls.Config
 
-	MasterHostPort    string
+	MasterHostPort    []string
 	OpTimeout         time.Duration
 	TLSCaCertFilePath string
 	TLSCertFilePath   string
@@ -35,7 +35,7 @@ func NewCliConfig() *CliConfig {
 // FlagSet returns an instance of the flag set for the configuration.
 func (c *CliConfig) FlagSet() *pflag.FlagSet {
 	if c.initFlagSet() {
-		c.flagSet.StringVar(&c.MasterHostPort, "master", "127.0.0.1:7100", "Master host port")
+		c.flagSet.StringSliceVar(&c.MasterHostPort, "master", []string{"127.0.0.1:7100", "127.0.0.1:7101", "127.0.0.1:7102"}, "Master host port")
 		c.flagSet.DurationVar(&c.OpTimeout, "operation-timeout", time.Duration(time.Second*60), "Operation timeout")
 		c.flagSet.StringVar(&c.TLSCaCertFilePath, "tls-ca-cert-file-path", "", "TLS CA certificate file path")
 		c.flagSet.StringVar(&c.TLSCertFilePath, "tls-cert-file-path", "", "TLS certificate file path")
@@ -77,8 +77,8 @@ func (c *CliConfig) TLSConfig() (*tls.Config, error) {
 
 // Validate validates the correctness of the configuration.
 func (c *CliConfig) Validate() error {
-	if c.MasterHostPort == "" {
-		return fmt.Errorf("--master is required")
+	if len(c.MasterHostPort) == 0 {
+		return fmt.Errorf("at least one --master is required")
 	}
 	if c.TLSCertFilePath != "" && c.TLSKeyFilePath == "" {
 		return fmt.Errorf("both --tls-cert-file-path and --tls-key-file-path are required")

--- a/configs/ybclient.go
+++ b/configs/ybclient.go
@@ -12,13 +12,13 @@ type YBClientConfig struct {
 }
 
 // NewYBClientConfigFromCliConfig constructs YB client config from the cli config.
-func NewYBClientConfigFromCliConfig(input *CliConfig) (*YBClientConfig, error) {
+func NewYBClientConfigFromCliConfig(hostPort string, input *CliConfig) (*YBClientConfig, error) {
 	tlsConfig, err := input.TLSConfig()
 	if err != nil {
 		return nil, err
 	}
 	return &YBClientConfig{
-		MasterHostPort: input.MasterHostPort,
+		MasterHostPort: hostPort,
 		TLSConfig:      tlsConfig,
 		OpTimeout:      uint32(input.OpTimeout.Milliseconds()),
 	}, nil


### PR DESCRIPTION
This PR adds support for the repeated `--master` flag and a reference of a leader master client discovery.