### PR TITLE
Better restore target

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,28 +280,19 @@ Examples:
 ##### restore-snapshot
 
 - `--schedule-id`: string, schedule identifier - literal ID or Base64 encoded value from YugabyteDB RPC API, required, default `empty string` (not defined)
-- `--restore-at`: uint64, absolute Timing Option: Max HybridTime, in micros, default `0` (undefined)
-- `--restore-relative`: duration expression (`1h`, `1d`, ...), relative restore time in the past to fetched server clock time, takes precedence when specified, default `0`
-
-When `--restore-at` and `--restore-relative` are not specified or bot hare set to `0`, restores to the given snapshot's creation time.
+- `--restore-target`: exact past HT (`16 digit literal`) or duration expression (`1h`, `5h15m`, ...), absolute Timing Option: Max HybridTime, or relative past interval, default `empty` (undefined)
 
 ##### restore-snapshot-schedule
 
 - `--snapshot-id`: string, snapshot identifier - literal ID or Base64 encoded value from YugabyteDB RPC API, required, default `empty string` (not defined)
-- `--restore-at`: uint64, absolute Timing Option: Max HybridTime, in micros, default `0` (undefined)
-- `--restore-relative`: duration expression (`1h`, `1d`, ...), relative restore time in the past to fetched server clock time, takes precedence when specified, default `0`
-
-When `--restore-at` and `--restore-relative` are not specified or bot hare set to `0`, restores to the given snapshot's creation time.
+- `--restore-target`: exact past HT (`16 digit literal`) or duration expression (`1h`, `5h15m`, ...), absolute Timing Option: Max HybridTime, or relative past interval, default `empty` (undefined)
 
 ##### create-snapshot-schedule
-
-Choose on: `--delete-after` or `--delete-at`.
 
 - `--keyspace`: string, keyspace name to create snapshot of, default `<empty string>`
 - `--interval`: duration expression (`1h`, `1d`, ...), interval for taking snapshot in seconds, default `0` (undefined)
 - `--retention-duration`: duration expression (`1h`, `1d`, ...), how long store snapshots in seconds, default `0` (undefined)
-- `--delete-after`: duration expression (`1h`, `1d`, ...), how long until schedule is removed in seconds, hybrid time will be calculated by fetching server hybrid time and adding this value, default `0` (undefined)
-- `--delete-at`: duration expression (`1h`, `1d`, ...), how long until schedule is removed in seconds, hybrid time will be calculated by fetching server hybrid time and adding this value, default `0` (undefined)
+- `--delete-after`: exact future HT (`16 digit literal`) or duration expression (`1h`, `5h15m`, ...), how long until schedule is removed in seconds, hybrid time will be calculated by fetching server hybrid time and adding this value, default `0` (undefined)
 
 Examples:
 

--- a/client/implementation/op_server_clock.go
+++ b/client/implementation/op_server_clock.go
@@ -1,8 +1,21 @@
 package implementation
 
 import (
+	"fmt"
+
 	ybApi "github.com/radekg/yugabyte-db-go-proto/v2/yb/api"
 )
+
+func (c *defaultYBCliClient) defaultServerClockResolver() (uint64, error) {
+	serverClock, err := c.ServerClock()
+	if err != nil {
+		return 0, err
+	}
+	if serverClock.HybridTime == nil {
+		return 0, fmt.Errorf("no hybrid time in server clock response")
+	}
+	return *serverClock.HybridTime, nil
+}
 
 // Gets the server clock value.
 // Returned server time is represented in microseconds.

--- a/client/implementation/op_snapshots_create_schedule.go
+++ b/client/implementation/op_snapshots_create_schedule.go
@@ -39,8 +39,14 @@ func (c *defaultYBCliClient) SnapshotsCreateSchedule(opConfig *configs.OpSnapsho
 		}()
 	}
 
-	futureTime, err := relativetime.RelativeOrFixedFuture(opConfig.DeleteTime,
-		opConfig.DeleteAfter,
+	deleteFixedTime, deleteDuration, err := relativetime.ParseTimeOrDuration(opConfig.DeleteAfter)
+	if err != nil {
+		c.logger.Error("invalid delete after expression", "expression", opConfig.DeleteAfter, "reason", err)
+		return nil, err
+	}
+
+	futureTime, err := relativetime.RelativeOrFixedFuture(deleteFixedTime,
+		deleteDuration,
 		c.defaultServerClockResolver)
 	if err != nil {
 		c.logger.Error("failed resolving delete at time", "reason", err)

--- a/client/implementation/op_snapshots_create_schedule.go
+++ b/client/implementation/op_snapshots_create_schedule.go
@@ -1,9 +1,9 @@
 package implementation
 
 import (
-	"fmt"
-
 	"github.com/radekg/yugabyte-db-go-client/configs"
+	"github.com/radekg/yugabyte-db-go-client/utils"
+	"github.com/radekg/yugabyte-db-go-client/utils/relativetime"
 	ybApi "github.com/radekg/yugabyte-db-go-proto/v2/yb/api"
 )
 
@@ -38,19 +38,16 @@ func (c *defaultYBCliClient) SnapshotsCreateSchedule(opConfig *configs.OpSnapsho
 			return &v
 		}()
 	}
-	if opConfig.DeleteTime > 0 {
-		payload.Options.DeleteTime = &opConfig.DeleteTime
+
+	futureTime, err := relativetime.RelativeOrFixedFuture(opConfig.DeleteTime,
+		opConfig.DeleteAfter,
+		c.defaultServerClockResolver)
+	if err != nil {
+		c.logger.Error("failed resolving delete at time", "reason", err)
+		return nil, err
 	}
-	if opConfig.DeleteAfter > 0 {
-		serverClock, err := c.ServerClock()
-		if err != nil {
-			return nil, err
-		}
-		if serverClock.HybridTime == nil {
-			return nil, fmt.Errorf("no hybrid time in server clock response")
-		}
-		newHybridTime := *serverClock.HybridTime + uint64(opConfig.DeleteAfter.Microseconds())
-		payload.Options.DeleteTime = &newHybridTime
+	if futureTime > 0 {
+		payload.Options.DeleteTime = utils.PUint64(futureTime)
 	}
 
 	responsePayload := &ybApi.CreateSnapshotScheduleResponsePB{}

--- a/client/implementation/op_snapshots_restore.go
+++ b/client/implementation/op_snapshots_restore.go
@@ -23,8 +23,14 @@ func (c *defaultYBCliClient) SnapshotsRestore(opConfig *configs.OpSnapshotRestor
 		SnapshotId: ybDbID.Bytes(),
 	}
 
-	relativeTime, err := relativetime.RelativeOrFixedPast(opConfig.RestoreAt,
-		opConfig.RestoreRelative,
+	restoreFixedTime, restoreDuration, err := relativetime.ParseTimeOrDuration(opConfig.RestoreTarget)
+	if err != nil {
+		c.logger.Error("invalid restore target expression", "expression", opConfig.RestoreTarget, "reason", err)
+		return nil, err
+	}
+
+	relativeTime, err := relativetime.RelativeOrFixedPast(restoreFixedTime,
+		restoreDuration,
 		c.defaultServerClockResolver)
 	if err != nil {
 		c.logger.Error("failed resolving restore target time", "reason", err)

--- a/client/implementation/op_snapshots_restore.go
+++ b/client/implementation/op_snapshots_restore.go
@@ -3,7 +3,7 @@ package implementation
 import (
 	"github.com/radekg/yugabyte-db-go-client/configs"
 	"github.com/radekg/yugabyte-db-go-client/utils"
-	"github.com/radekg/yugabyte-db-go-client/utils/restoretarget"
+	"github.com/radekg/yugabyte-db-go-client/utils/relativetime"
 	"github.com/radekg/yugabyte-db-go-client/utils/ybdbid"
 	ybApi "github.com/radekg/yugabyte-db-go-proto/v2/yb/api"
 )
@@ -23,7 +23,7 @@ func (c *defaultYBCliClient) SnapshotsRestore(opConfig *configs.OpSnapshotRestor
 		SnapshotId: ybDbID.Bytes(),
 	}
 
-	relativeTime, err := restoretarget.RelativeOrFixedPast(opConfig.RestoreAt,
+	relativeTime, err := relativetime.RelativeOrFixedPast(opConfig.RestoreAt,
 		opConfig.RestoreRelative,
 		c.defaultServerClockResolver)
 	if err != nil {

--- a/client/implementation/op_snapshots_restore_schedule.go
+++ b/client/implementation/op_snapshots_restore_schedule.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/radekg/yugabyte-db-go-client/configs"
-	"github.com/radekg/yugabyte-db-go-client/utils"
+	"github.com/radekg/yugabyte-db-go-client/utils/restoretarget"
 	"github.com/radekg/yugabyte-db-go-client/utils/ybdbid"
 	ybApi "github.com/radekg/yugabyte-db-go-proto/v2/yb/api"
 )
@@ -13,7 +13,9 @@ import (
 // Restore schedule.
 func (c *defaultYBCliClient) SnapshotsRestoreSchedule(opConfig *configs.OpSnapshotRestoreScheduleConfig) (*ybApi.RestoreSnapshotResponsePB, error) {
 
-	restoreAt, err := getRestoreScheduleAt(c, opConfig)
+	restoreAt, err := restoretarget.RelativeOrFixedPastWithFallback(opConfig.RestoreAt,
+		opConfig.RestoreRelative,
+		c.defaultServerClockResolver)
 	if err != nil {
 		return nil, fmt.Errorf("could not establish restore at time")
 	}
@@ -174,35 +176,4 @@ func (c *defaultYBCliClient) snapshotSuitableForRestoreAt(entry *ybApi.SysSnapsh
 		return *entry.SnapshotHybridTime >= restoreAt && *entry.PreviousSnapshotHybridTime < restoreAt
 	}
 	return false
-}
-
-func getRestoreScheduleAt(c *defaultYBCliClient, opConfig *configs.OpSnapshotRestoreScheduleConfig) (uint64, error) {
-
-	restoreAt := uint64(0)
-
-	if opConfig.RestoreAt > 0 {
-		restoreAt = opConfig.RestoreAt
-	}
-
-	if opConfig.RestoreRelative > 0 {
-		serverClock, err := c.ServerClock()
-		if err != nil {
-			return 0, err
-		}
-		if serverClock.HybridTime == nil {
-			return 0, fmt.Errorf("no hybrid time in server clock response")
-		}
-		restoreAt = *serverClock.HybridTime - utils.ClockTimestampToHTTimestamp(uint64(opConfig.RestoreRelative.Microseconds()))
-		return restoreAt, nil
-	}
-
-	serverClock, err := c.ServerClock()
-	if err != nil {
-		return 0, err
-	}
-	if serverClock.HybridTime == nil {
-		return 0, fmt.Errorf("no hybrid time in server clock response")
-	}
-	return *serverClock.HybridTime, nil
-
 }

--- a/client/implementation/op_snapshots_restore_schedule.go
+++ b/client/implementation/op_snapshots_restore_schedule.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/radekg/yugabyte-db-go-client/configs"
-	"github.com/radekg/yugabyte-db-go-client/utils/restoretarget"
+	"github.com/radekg/yugabyte-db-go-client/utils/relativetime"
 	"github.com/radekg/yugabyte-db-go-client/utils/ybdbid"
 	ybApi "github.com/radekg/yugabyte-db-go-proto/v2/yb/api"
 )
@@ -13,7 +13,7 @@ import (
 // Restore schedule.
 func (c *defaultYBCliClient) SnapshotsRestoreSchedule(opConfig *configs.OpSnapshotRestoreScheduleConfig) (*ybApi.RestoreSnapshotResponsePB, error) {
 
-	restoreAt, err := restoretarget.RelativeOrFixedPastWithFallback(opConfig.RestoreAt,
+	restoreAt, err := relativetime.RelativeOrFixedPastWithFallback(opConfig.RestoreAt,
 		opConfig.RestoreRelative,
 		c.defaultServerClockResolver)
 	if err != nil {

--- a/configs/cfg_snapshots_create_schedule.go.go
+++ b/configs/cfg_snapshots_create_schedule.go.go
@@ -14,8 +14,7 @@ type OpSnapshotCreateScheduleConfig struct {
 	Keyspace              string
 	IntervalSecs          time.Duration
 	RetendionDurationSecs time.Duration
-	DeleteAfter           time.Duration
-	DeleteTime            uint64
+	DeleteAfter           string
 }
 
 // NewOpSnapshotCreateScheduleConfig returns an instance of the command specific config.
@@ -29,8 +28,7 @@ func (c *OpSnapshotCreateScheduleConfig) FlagSet() *pflag.FlagSet {
 		c.flagSet.StringVar(&c.Keyspace, "keyspace", "", "Keyspace for the tables in this create request")
 		c.flagSet.DurationVar(&c.IntervalSecs, "interval", time.Second*0, "Interval for taking snapshot in seconds")
 		c.flagSet.DurationVar(&c.RetendionDurationSecs, "retention-duration", time.Second*0, "How long store snapshots in seconds")
-		c.flagSet.DurationVar(&c.DeleteAfter, "delete-after", time.Second*0, "How long until schedule is removed in seconds, hybrid time will be calculated by fetching server hybrid time and adding this value")
-		c.flagSet.Uint64Var(&c.DeleteTime, "delete-at", 0, "Hybrid time when this schedule is deleted")
+		c.flagSet.StringVar(&c.DeleteAfter, "delete-after", "", "How long until schedule is removed in seconds, hybrid time will be calculated by fetching server hybrid time and adding this value")
 	}
 	return c.flagSet
 }
@@ -39,9 +37,6 @@ func (c *OpSnapshotCreateScheduleConfig) FlagSet() *pflag.FlagSet {
 func (c *OpSnapshotCreateScheduleConfig) Validate() error {
 	if c.Keyspace == "" {
 		return fmt.Errorf("--keyspace is required")
-	}
-	if c.DeleteAfter.Milliseconds() > 0 && c.DeleteTime > 0 {
-		return fmt.Errorf("--delete-after and --delete-at specified, choose one")
 	}
 	return nil
 }

--- a/configs/cfg_snapshots_restore.go
+++ b/configs/cfg_snapshots_restore.go
@@ -2,7 +2,6 @@ package configs
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/spf13/pflag"
 )
@@ -11,9 +10,8 @@ import (
 type OpSnapshotRestoreConfig struct {
 	flagBase
 
-	SnapshotID      string
-	RestoreAt       uint64
-	RestoreRelative time.Duration
+	SnapshotID    string
+	RestoreTarget string
 }
 
 // NewOpSnapshotRestoreConfig returns an instance of the command specific config.
@@ -25,8 +23,7 @@ func NewOpSnapshotRestoreConfig() *OpSnapshotRestoreConfig {
 func (c *OpSnapshotRestoreConfig) FlagSet() *pflag.FlagSet {
 	if c.initFlagSet() {
 		c.flagSet.StringVar(&c.SnapshotID, "snapshot-id", "", "Snapshot identifier")
-		c.flagSet.Uint64Var(&c.RestoreAt, "restore-at", 0, "Absolute Timing Option: Max HybridTime, in Micros")
-		c.flagSet.DurationVar(&c.RestoreRelative, "restore-relative", 0, "Relative restore time in the past to fetched server clock time, takes precedence when specified")
+		c.flagSet.StringVar(&c.RestoreTarget, "restore-target", "", "Absolute Timing Option: Max HybridTime, in Micros or duration expression")
 	}
 	return c.flagSet
 }
@@ -35,9 +32,6 @@ func (c *OpSnapshotRestoreConfig) FlagSet() *pflag.FlagSet {
 func (c *OpSnapshotRestoreConfig) Validate() error {
 	if c.SnapshotID == "" {
 		return fmt.Errorf("--snapshot-id required")
-	}
-	if c.RestoreAt > 0 && c.RestoreRelative > 0 {
-		return fmt.Errorf("--restore-at or --restore-relative: choose one")
 	}
 	return nil
 }

--- a/configs/cfg_snapshots_restore_schedule.go
+++ b/configs/cfg_snapshots_restore_schedule.go
@@ -2,7 +2,6 @@ package configs
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/spf13/pflag"
 )
@@ -11,9 +10,8 @@ import (
 type OpSnapshotRestoreScheduleConfig struct {
 	flagBase
 
-	ScheduleID      string
-	RestoreAt       uint64
-	RestoreRelative time.Duration
+	ScheduleID    string
+	RestoreTarget string
 }
 
 // NewOpSnapshotRestoreScheduleConfig returns an instance of the command specific config.
@@ -25,8 +23,7 @@ func NewOpSnapshotRestoreScheduleConfig() *OpSnapshotRestoreScheduleConfig {
 func (c *OpSnapshotRestoreScheduleConfig) FlagSet() *pflag.FlagSet {
 	if c.initFlagSet() {
 		c.flagSet.StringVar(&c.ScheduleID, "schedule-id", "", "Schedule identifier")
-		c.flagSet.Uint64Var(&c.RestoreAt, "restore-at", 0, "Absolute Timing Option: Max HybridTime, in Micros")
-		c.flagSet.DurationVar(&c.RestoreRelative, "restore-relative", 0, "Relative restore time in the past to fetched server clock time, takes precedence when specified")
+		c.flagSet.StringVar(&c.RestoreTarget, "restore-target", "", "Absolute Timing Option: Max HybridTime, in Micros or duration expression")
 	}
 	return c.flagSet
 }
@@ -35,9 +32,6 @@ func (c *OpSnapshotRestoreScheduleConfig) FlagSet() *pflag.FlagSet {
 func (c *OpSnapshotRestoreScheduleConfig) Validate() error {
 	if c.ScheduleID == "" {
 		return fmt.Errorf("--schedule-id required")
-	}
-	if c.RestoreAt > 0 && c.RestoreRelative > 0 {
-		return fmt.Errorf("--restore-at or --restore-relative: choose one")
 	}
 	return nil
 }

--- a/utils/hybridtime/hybrid_time.go
+++ b/utils/hybridtime/hybrid_time.go
@@ -1,4 +1,6 @@
-package utils
+package hybridtime
+
+import "time"
 
 const hybridTimeNumBitsToShift = 12
 
@@ -25,4 +27,14 @@ func HTTimestampToPhysicalAndLogical(htTimestamp uint64) []uint64 {
 // https://github.com/yugabyte/yugabyte-db/blob/master/java/yb-client/src/main/java/org/yb/util/HybridTimeUtil.java#L82
 func PhysicalAndLogicalToHTTimestamp(physical uint64, logical uint64) uint64 {
 	return (physical << uint64(hybridTimeNumBitsToShift)) + logical
+}
+
+// AddDuration adds a duration to HT.
+func AddDuration(ht uint64, d time.Duration) uint64 {
+	return ht + ClockTimestampToHTTimestamp(uint64(d.Microseconds()))
+}
+
+// SubstractDuration substracts a duration from HT.
+func SubstractDuration(ht uint64, d time.Duration) uint64 {
+	return ht - ClockTimestampToHTTimestamp(uint64(d.Microseconds()))
 }

--- a/utils/relativetime/parse.go
+++ b/utils/relativetime/parse.go
@@ -1,0 +1,29 @@
+package relativetime
+
+import (
+	"regexp"
+	"strconv"
+	"time"
+)
+
+// ParseTimeOrDuration parses input string as fixed HT or time.Duration.
+func ParseTimeOrDuration(input string) (uint64, time.Duration, error) {
+
+	// The HybridTime is given in microseconds and will contain 16 chars.
+	match, _ := regexp.MatchString("^(\\d{16})$", input)
+	if match {
+		n, err := strconv.ParseUint(input, 10, 64)
+		if err != nil {
+			return 0, 0, err
+		}
+		return n, 0, nil
+	}
+
+	d, err := time.ParseDuration(input)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return 0, d, err
+
+}

--- a/utils/relativetime/parse.go
+++ b/utils/relativetime/parse.go
@@ -9,6 +9,10 @@ import (
 // ParseTimeOrDuration parses input string as fixed HT or time.Duration.
 func ParseTimeOrDuration(input string) (uint64, time.Duration, error) {
 
+	if input == "" {
+		return 0, 0, nil
+	}
+
 	// The HybridTime is given in microseconds and will contain 16 chars.
 	match, _ := regexp.MatchString("^(\\d{16})$", input)
 	if match {

--- a/utils/relativetime/parse_test.go
+++ b/utils/relativetime/parse_test.go
@@ -1,0 +1,33 @@
+package relativetime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseTimeOrDuration(t *testing.T) {
+
+	t.Run("it=parses what looks like HT", func(tt *testing.T) {
+		f, d, e := ParseTimeOrDuration("1234567890123456")
+		assert.Nil(tt, e)
+		assert.Equal(tt, time.Duration(0), d)
+		assert.Greater(tt, f, uint64(0))
+	})
+
+	t.Run("it=parses a valid duration string", func(tt *testing.T) {
+		f, d, e := ParseTimeOrDuration("48h15m5s")
+		assert.Nil(tt, e)
+		assert.Greater(tt, d, time.Duration(0))
+		assert.Equal(tt, uint64(0), f)
+	})
+
+	t.Run("it=handles invalid strings", func(tt *testing.T) {
+		f, d, e := ParseTimeOrDuration("invalid input")
+		assert.NotNil(tt, e)
+		assert.Equal(tt, time.Duration(0), d)
+		assert.Equal(tt, uint64(0), f)
+	})
+
+}

--- a/utils/relativetime/relative_time.go
+++ b/utils/relativetime/relative_time.go
@@ -1,4 +1,4 @@
-package restoretarget
+package relativetime
 
 import (
 	"time"

--- a/utils/restoretarget/restore_target.go
+++ b/utils/restoretarget/restore_target.go
@@ -1,0 +1,62 @@
+package restoretarget
+
+import (
+	"time"
+
+	"github.com/radekg/yugabyte-db-go-client/utils/hybridtime"
+)
+
+// ServerClockResolver defines a server clock resolver interface.
+type ServerClockResolver = func() (uint64, error)
+
+// RelativeOrFixedFuture returns a new restore target in the future if duration is specified,
+// or the fixed value.
+func RelativeOrFixedFuture(fixed uint64, relative time.Duration, resolver ServerClockResolver) (uint64, error) {
+	if relative > 0 {
+		serverClock, err := resolver()
+		if err != nil {
+			return 0, err
+		}
+		return hybridtime.AddDuration(serverClock, relative), nil
+	}
+	return fixed, nil
+}
+
+// RelativeOrFixedFutureWithFallback returns a new restore target in the future if duration is specified,
+// or the fixed value. If both values are 0, resolves new clock value using the resolver.
+func RelativeOrFixedFutureWithFallback(fixed uint64, relative time.Duration, resolver ServerClockResolver) (uint64, error) {
+	t, err := RelativeOrFixedFuture(fixed, relative, resolver)
+	if err != nil {
+		return 0, err
+	}
+	if t > 0 {
+		return t, nil
+	}
+	return resolver()
+}
+
+// RelativeOrFixedPast returns a new restore target in the past if duration is specified,
+// or the fixed value.
+func RelativeOrFixedPast(fixed uint64, relative time.Duration, resolver ServerClockResolver) (uint64, error) {
+	if relative > 0 {
+		serverClock, err := resolver()
+		if err != nil {
+			return 0, err
+		}
+		return hybridtime.SubstractDuration(serverClock, relative), nil
+	}
+	return fixed, nil
+}
+
+// RelativeOrFixedPastWithFallback returns a new restore target in the past if duration is specified,
+// or the fixed value. If both values are 0, resolves new clock value using the resolver.
+func RelativeOrFixedPastWithFallback(fixed uint64, relative time.Duration, resolver ServerClockResolver) (uint64, error) {
+	t, err := RelativeOrFixedPast(fixed, relative, resolver)
+	if err != nil {
+		return 0, err
+	}
+	if t > 0 {
+		return t, nil
+	}
+	return resolver()
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -107,6 +107,11 @@ func PUint32(a uint32) *uint32 {
 	return &a
 }
 
+// PUint64 returns a pointer to an uint64.
+func PUint64(a uint64) *uint64 {
+	return &a
+}
+
 // PString returns a pointer to a string.
 func PString(a string) *string {
 	if a == "" {

--- a/utils/ybdbid/ybdbid_test.go
+++ b/utils/ybdbid/ybdbid_test.go
@@ -13,21 +13,21 @@ func TestYBDBIDParsing(t *testing.T) {
 
 		validBase64YBDBID := "ugsZNctgSFSt0AhKDe7MzA=="
 		parsed, err := TryParseFromString(validBase64YBDBID)
-		assert.Nil(t, err)
-		assert.Equal(t, len(parsed.Bytes()), 16)
+		assert.Nil(tt, err)
+		assert.Equal(tt, len(parsed.Bytes()), 16)
 
 		parsedBackViaBytes, err := TryParseFromBytes(parsed.Bytes())
-		assert.Nil(t, err)
-		assert.Equal(t, parsed.UUID(), parsedBackViaBytes.UUID())
-		assert.Equal(t, parsed.String(), parsedBackViaBytes.String())
+		assert.Nil(tt, err)
+		assert.Equal(tt, parsed.UUID(), parsedBackViaBytes.UUID())
+		assert.Equal(tt, parsed.String(), parsedBackViaBytes.String())
 
 		parsedBackViaString, err := TryParseFromString(parsed.String())
-		assert.Nil(t, err)
-		assert.Equal(t, parsed.UUID(), parsedBackViaString.UUID())
-		assert.Equal(t, parsed.String(), parsedBackViaString.String())
+		assert.Nil(tt, err)
+		assert.Equal(tt, parsed.UUID(), parsedBackViaString.UUID())
+		assert.Equal(tt, parsed.String(), parsedBackViaString.String())
 
-		assert.Equal(t, validBase64YBDBID, base64.StdEncoding.EncodeToString(parsedBackViaBytes.Bytes()))
-		assert.Equal(t, validBase64YBDBID, base64.StdEncoding.EncodeToString(parsedBackViaString.Bytes()))
+		assert.Equal(tt, validBase64YBDBID, base64.StdEncoding.EncodeToString(parsedBackViaBytes.Bytes()))
+		assert.Equal(tt, validBase64YBDBID, base64.StdEncoding.EncodeToString(parsedBackViaString.Bytes()))
 
 	})
 
@@ -35,39 +35,39 @@ func TestYBDBIDParsing(t *testing.T) {
 
 		validYBDBID := "dfec75ee-290e-4f3b-b965-469a0246c133"
 		parsed, err := TryParseFromString(validYBDBID)
-		assert.Nil(t, err)
-		assert.Equal(t, len(parsed.Bytes()), 16)
+		assert.Nil(tt, err)
+		assert.Equal(tt, len(parsed.Bytes()), 16)
 
 		parsedBackViaBytes, err := TryParseFromBytes(parsed.Bytes())
-		assert.Nil(t, err)
-		assert.Equal(t, parsed.UUID(), parsedBackViaBytes.UUID())
-		assert.Equal(t, parsed.String(), parsedBackViaBytes.String())
+		assert.Nil(tt, err)
+		assert.Equal(tt, parsed.UUID(), parsedBackViaBytes.UUID())
+		assert.Equal(tt, parsed.String(), parsedBackViaBytes.String())
 
 		parsedBackViaString, err := TryParseFromString(parsed.String())
-		assert.Nil(t, err)
-		assert.Equal(t, parsed.UUID(), parsedBackViaString.UUID())
-		assert.Equal(t, parsed.String(), parsedBackViaString.String())
+		assert.Nil(tt, err)
+		assert.Equal(tt, parsed.UUID(), parsedBackViaString.UUID())
+		assert.Equal(tt, parsed.String(), parsedBackViaString.String())
 
 	})
 
 	t.Run("it=handles invalid base64 encoded input", func(tt *testing.T) {
 		invalidBase64YBDBID := base64.StdEncoding.EncodeToString([]byte("this isn't a YBDBID"))
 		parsed, err := TryParseFromString(invalidBase64YBDBID)
-		assert.NotNil(t, err)
-		assert.Nil(t, parsed)
+		assert.NotNil(tt, err)
+		assert.Nil(tt, parsed)
 	})
 
 	t.Run("it=handles non-UUID input", func(tt *testing.T) {
 		invalidYBDBID := "dfec75ee-290e-4f3b---b965-469a0246c133"
 		parsed, err := TryParseFromString(invalidYBDBID)
-		assert.NotNil(t, err)
-		assert.Nil(t, parsed)
+		assert.NotNil(tt, err)
+		assert.Nil(tt, parsed)
 	})
 
 	t.Run("it=handles null byte input", func(tt *testing.T) {
 		parsed, err := TryParseFromBytes(nil)
-		assert.NotNil(t, err)
-		assert.Nil(t, parsed)
+		assert.NotNil(tt, err)
+		assert.Nil(tt, parsed)
 	})
 
 }


### PR DESCRIPTION
This PR brings the `--restore-target` flag in the direction of `yb-admin`. It uses a single flag to parse either an exact HT, or a duration expression. It does not support PostgreSQL compatible duration expressions yet. Additionally, this PR tidies up HT operations.